### PR TITLE
feat(intersolia): add UpCloud and Turbo remote cache env vars

### DIFF
--- a/source/intersolia/dot_envrc.tmpl
+++ b/source/intersolia/dot_envrc.tmpl
@@ -22,3 +22,13 @@ export TF_CMD=terraform
 
 # Grafana logs token
 export CLAUDE_GRAFANA_TOKEN={{ protonPass "pass://Intersolia/auths/ClaudeGrafanaToken" | trim }}
+
+# Upcloud token
+export UPCLOUD_USERNAME=terraform-dev
+export UPCLOUD_PASSWORD={{ protonPass "pass://Intersolia/auths/UpCloudToken" | trim }}
+
+# Turbo remote repo
+export TURBO_TOKEN=${GITHUB_TOKEN}
+export TURBO_API=https://turbo-cache.platform.intersolia.io
+export TURBO_TEAM=intersolia
+export TURBO_TEAMID=team_intersolia


### PR DESCRIPTION
## Summary
- Add `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` (via Proton Pass) for Terraform UpCloud provider
- Add Turbo remote cache config (`TURBO_TOKEN`, `TURBO_API`, `TURBO_TEAM`, `TURBO_TEAMID`)

## Test plan
- [ ] `chezmoi apply` renders `source/intersolia/.envrc` with resolved secrets
- [ ] `direnv allow` loads the env vars in the Intersolia workspace
- [ ] Terraform can authenticate against UpCloud with the new credentials